### PR TITLE
Fix NA representation for tabular outputs

### DIFF
--- a/R/read_vcf.R
+++ b/R/read_vcf.R
@@ -149,6 +149,8 @@ read_vcf <- function(path,
             file = save_path, 
             sep = "\t",
             nThread = nThread,
+            na = "NA",
+            quote = FALSE
         )
     } 
     return(vcf_dt)

--- a/R/read_vcf.R
+++ b/R/read_vcf.R
@@ -1,12 +1,12 @@
 #' Read in VCF file
-#' 
-#' Read in a VCF file as a \link[VariantAnnotation]{VCF} or a 
-#' \link[data.table]{data.table}. 
-#' Can optionally save the VCF/data.table as well. 
-#' 
+#'
+#' Read in a VCF file as a \link[VariantAnnotation]{VCF} or a
+#' \link[data.table]{data.table}.
+#' Can optionally save the VCF/data.table as well.
+#'
 #' @param path Path to local or remote VCF file.
 #' @param as_datatable Return the data as a
-#'  \link[data.table]{data.table} (default: \code{TRUE}) 
+#'  \link[data.table]{data.table} (default: \code{TRUE})
 #'  or a \link[VariantAnnotation]{VCF} (\code{FALSE}).
 #' @param samples Which samples to use:
 #' \itemize{
@@ -15,19 +15,19 @@
 #' \item{c("<sample_id1>","<sample_id2>",...) : }{
 #' Only user-selected samples will be used (case-insensitive).}
 #' }
-#' @param use_params 
+#' @param use_params
 #' When \code{TRUE} (default), increases the speed of reading in the VCF by
-#' omitting columns that are empty based on the head of the VCF (NAs only). 
-#' NOTE that that this requires the VCF to be sorted, bgzip-compressed, 
+#' omitting columns that are empty based on the head of the VCF (NAs only).
+#' NOTE that that this requires the VCF to be sorted, bgzip-compressed,
 #' tabix-indexed, which \link[MungeSumstats]{read_vcf} will attempt to do.
-#' @param download Download the VCF (and its index file) 
-#' to a temp folder before reading it into R. 
+#' @param download Download the VCF (and its index file)
+#' to a temp folder before reading it into R.
 #' This is important to keep \code{TRUE} when \code{nThread>1} to avoid
-#' making too many queries to remote file. 
-#' @param mt_thresh When the number of rows (variants) in the VCF is 
+#' making too many queries to remote file.
+#' @param mt_thresh When the number of rows (variants) in the VCF is
 #' \code{< mt_thresh}, only use single-threading for reading in the VCF.
 #' This is because the overhead of parallelisation outweighs the speed benefits
-#' when VCFs are small. 
+#' when VCFs are small.
 #' @param verbose Print messages.
 #' @inheritParams check_empty_cols
 #' @inheritParams format_sumstats
@@ -38,9 +38,9 @@
 #'
 #' @return The VCF file in data.table format.
 #' @export
-#' @importFrom VariantAnnotation writeVcf 
-#' @importFrom data.table as.data.table setnames fwrite 
-#' @source 
+#' @importFrom VariantAnnotation writeVcf
+#' @importFrom data.table as.data.table setnames fwrite
+#' @source
 #' \code{
 #' #### Benchmarking ####
 #' library(VCFWrenchR)
@@ -60,25 +60,25 @@
 #' @source \href{https://github.com/Bioconductor/VariantAnnotation/issues/57}{
 #' Discussion on VariantAnnotation GitHub}
 #' @source \href{https://github.com/Bioconductor/VariantAnnotation/issues/59}{
-#' Discussion on VariantAnnotation GitHub} 
-#' @examples 
+#' Discussion on VariantAnnotation GitHub}
+#' @examples
 #' #### Local file ####
 #' path <- system.file("extdata","ALSvcf.vcf", package="MungeSumstats")
 #' sumstats_dt <- read_vcf(path = path)
-#' 
+#'
 #' #### Remote file ####
 #' ## Small GWAS (0.2Mb)
-#' # path <- "https://gwas.mrcieu.ac.uk/files/ieu-a-298/ieu-a-298.vcf.gz" 
+#' # path <- "https://gwas.mrcieu.ac.uk/files/ieu-a-298/ieu-a-298.vcf.gz"
 #' # sumstats_dt2 <- read_vcf(path = path)
-#' 
+#'
 #' ## Large GWAS (250Mb)
 #' # path <- "https://gwas.mrcieu.ac.uk/files/ubm-a-2929/ubm-a-2929.vcf.gz"
 #' # sumstats_dt3 <- read_vcf(path = path, nThread=11)
-#' 
+#'
 #' ### Very large GWAS (500Mb)
 #' # path <- "https://gwas.mrcieu.ac.uk/files/ieu-a-1124/ieu-a-1124.vcf.gz"
 #' # sumstats_dt4 <- read_vcf(path = path, nThread=11)
-read_vcf <- function(path, 
+read_vcf <- function(path,
                      as_datatable = TRUE,
                      save_path = NULL,
                      tabix_index = FALSE,
@@ -92,8 +92,8 @@ read_vcf <- function(path,
                      force_new = FALSE,
                      mt_thresh = 1e5L,
                      nThread = 1,
-                     verbose = TRUE){ 
-    #### Read VCF #### 
+                     verbose = TRUE) {
+    #### Read VCF ####
     ## Returns either a VCF or a data.table, depending on as_datatable arg.
     vcf_dt <- read_vcf_parallel(path = path,
                                 samples = samples,
@@ -101,28 +101,28 @@ read_vcf <- function(path,
                                 use_params = use_params,
                                 as_datatable = as_datatable,
                                 sampled_rows = sampled_rows,
-                                
+
                                 download = download,
                                 vcf_dir = vcf_dir,
                                 download_method = download_method,
-                                force_new = force_new, 
+                                force_new = force_new,
                                 nThread = nThread,
                                 verbose = verbose)
     #### Check save path ####
-    if(!is.null(save_path)){
+    if (!is.null(save_path)) {
         check_save_path_out <- check_save_path(
             ### dummy arg, not used here
-            log_folder = "NULL", 
+            log_folder = "NULL",
             ### dummy arg, not used here
-            log_folder_ind = FALSE, 
-            save_path = save_path, 
+            log_folder_ind = FALSE,
+            save_path = save_path,
             write_vcf = !as_datatable,
             tabix_index = tabix_index)
         save_path <- check_save_path_out$save_path
     }
     #### Save as VCF ####
-    if(isFALSE(as_datatable)) {
-        if(!is.null(save_path)){ 
+    if (isFALSE(as_datatable)) {
+        if (!is.null(save_path)) {
             VariantAnnotation::writeVcf(
                 obj = vcf_dt,
                 filename = check_save_path_out$save_path,
@@ -131,27 +131,27 @@ read_vcf <- function(path,
         }
         messager("Returning as VCF.")
         return(vcf_dt)
-    } 
+    }
     #### Prepare SNP column ####
-    read_vcf_markername(sumstats_dt = vcf_dt) 
+    read_vcf_markername(sumstats_dt = vcf_dt)
     #### Prepare/un-log P col ####
-    read_vcf_pval(sumstats_dt = vcf_dt)  
+    read_vcf_pval(sumstats_dt = vcf_dt)
     #### Prepare INFO col ####
-    read_vcf_info(sumstats_dt = vcf_dt)  
+    read_vcf_info(sumstats_dt = vcf_dt)
     #### Rename start col #####
-    data.table::setnames(vcf_dt,"start","BP")
+    data.table::setnames(vcf_dt, "start", "BP")
     #### Write new data ####
-    if (!is.null(save_path)) { 
-        messager("Storing intermediate file before proceeding ==>",save_path,
-                 v=verbose)
+    if (!is.null(save_path)) {
+        messager("Storing intermediate file before proceeding ==>", save_path,
+                 v = verbose)
         data.table::fwrite(
             x = vcf_dt,
-            file = save_path, 
+            file = save_path,
             sep = "\t",
             nThread = nThread,
             na = "NA",
             quote = FALSE
         )
-    } 
+    }
     return(vcf_dt)
 }

--- a/R/write_sumstats.R
+++ b/R/write_sumstats.R
@@ -6,13 +6,13 @@
 #'  This will have been modified in some cases
 #'   (e.g. after compressing and tabix-indexing a
 #'    previously un-compressed file).
-#' @param save_path_check Ensure path name is valid (given the other arguments) 
-#' before writing (default: FALSE). 
+#' @param save_path_check Ensure path name is valid (given the other arguments)
+#' before writing (default: FALSE).
 #' @inheritParams data.table::fread
 #' @inheritParams format_sumstats
-#' 
+#'
 #' @source \href{https://github.com/Bioconductor/VariantAnnotation/issues/35}{
-#' VariantAnnotation::writeVcf has some unexpected/silent 
+#' VariantAnnotation::writeVcf has some unexpected/silent
 #' file renaming behavior}
 #'
 #' @returns If \code{return_path=TRUE}, returns \code{save_path}.
@@ -41,27 +41,27 @@ write_sumstats <- function(sumstats_dt,
                            return_path = FALSE,
                            save_path_check = FALSE) {
     #### Check save_path ####
-    if(isTRUE(save_path_check)){
-        check <- check_save_path(save_path = save_path, 
+    if (isTRUE(save_path_check)) {
+        check <- check_save_path(save_path = save_path,
                                  log_folder = tempdir(),
                                  log_folder_ind = FALSE,
-                                 tabix_index = tabix_index, 
+                                 tabix_index = tabix_index,
                                  write_vcf = write_vcf,
                                  verbose = TRUE)
         save_path <- check$save_path
-    } 
+    }
     #### Sort again just to be sure when tabix-indexing ####
     if (isTRUE(tabix_index) ||
-       isTRUE(write_vcf)) {
+        isTRUE(write_vcf)) {
       sumstats_dt <- sort_coords(sumstats_dt = sumstats_dt)
     }
     #### Select write format ####
-    if (isTRUE(write_vcf)) { 
-        tmp_save_path <- gsub("\\.bgz|\\.gz","",save_path)
+    if (isTRUE(write_vcf)) {
+        tmp_save_path <- gsub("\\.bgz|\\.gz", "", save_path)
         #convert to IEU OpenGWAS VCF format (column naming and RSID position)
-        if(!is.null(save_format) && 
-           tolower(save_format)=="opengwas"){
-          #first check genome build - all of openGWAS is GRCh37 currently so 
+        if (!is.null(save_format) &&
+            tolower(save_format) == "opengwas") {
+          #first check genome build - all of openGWAS is GRCh37 currently so
           #warn user if their data isn't
           gen_build_err <- paste0("Your sumstats has been built on the ",
                                   ref_genome, " reference genome. However, ",
@@ -69,73 +69,73 @@ write_sumstats <- function(sumstats_dt,
                                   "currently built on GRCh37. Use the ",
                                   "convert_ref_genome parameter to liftover to",
                                   " GRCh37 by rerunning format_sumstats.")
-          if(toupper(ref_genome)!="GRCH37")
+          if (toupper(ref_genome) != "GRCH37")
             warning(gen_build_err)
           #necessary cols (https://github.com/MRCIEU/gwas-vcf-specification):
           #NS:NC:ES:SE:LP:AF:AC
           #p-val needs to be -log10 p
           #SNP -> RSID in INFO col
-          if("SNP" %in% colnames(sumstats_dt)){
-            setnames(sumstats_dt,"SNP","RSID")
+          if ("SNP" %in% colnames(sumstats_dt)) {
+            setnames(sumstats_dt, "SNP", "RSID")
           } else{
             stop("SNP/RSID is required for IEU OpenGWAS format VCFs")
           }
           #remove any extra columns
-          opengwas_cols <- c("RSID","CHR","BP","A1","A2","P",
-                              "FRQ","BETA","SE","N","N_CAS")
-          if(any(!(colnames(sumstats_dt) %in% opengwas_cols)))
-            sumstats_dt[,colnames(sumstats_dt)[!(colnames(sumstats_dt) %in% 
-                                                    opengwas_cols)]:=NULL]
+          opengwas_cols <- c("RSID", "CHR", "BP", "A1", "A2", "P",
+                             "FRQ", "BETA", "SE", "N", "N_CAS")
+          if (any(!(colnames(sumstats_dt) %in% opengwas_cols)))
+            sumstats_dt[, colnames(sumstats_dt)[!(colnames(sumstats_dt) %in%
+                                                  opengwas_cols)] := NULL]
           #### Convert to VRanges and save ####
-          vr <- to_vranges(sumstats_dt = sumstats_dt) 
-          if("P" %in% names(mcols(vr))){
+          vr <- to_vranges(sumstats_dt = sumstats_dt)
+          if ("P" %in% names(mcols(vr))) {
             #P -> LP
-            vr$LP <- -log(vr$P,base=10)
+            vr$LP <- -log(vr$P, base = 10)
             vr$P <- NULL
-          }else{
+          } else {
             stop("P-value is required for IEU OpenGWAS format VCFs")
           }
           #FRQ -> AF
-          if("FRQ" %in% names(mcols(vr))){
+          if ("FRQ" %in% names(mcols(vr))) {
             vr$AF <- vr$FRQ
             vr$FRQ <- NULL
           }
           #BETA -> ES
-          if("BETA" %in% names(mcols(vr))){
+          if ("BETA" %in% names(mcols(vr))) {
             vr$ES <- vr$BETA
             vr$BETA <- NULL
-          }else{
+          } else {
             stop("BETA (Effect Size) is required for IEU OpenGWAS format VCFs")
           }
           #SE -> SE
-          if(!"SE" %in% names(mcols(vr))){
+          if (!"SE" %in% names(mcols(vr))) {
             se_msg <- paste0("Standard Error (of effect size) is required for",
                               " IEU OpenGWAS format VCFs")
             stop(se_msg)
           }
           #N -> NS
-          if("N" %in% names(mcols(vr))){
+          if ("N" %in% names(mcols(vr))) {
             vr$NS <- vr$N
             vr$N <- NULL
           }
           #N_CAS -> NC
-          if("N_CAS" %in% names(mcols(vr))){
+          if ("N_CAS" %in% names(mcols(vr))) {
             vr$NC <- vr$N_CAS
             vr$N_CAS <- NULL
           }
           #reorder cols and drop any unnecessary
-          all_poss_cols <- c("RSID","NS","NC","ES","SE","LP","AF","AC")
-          vr <- vr[,all_poss_cols[all_poss_cols %in% names(mcols(vr))]]
-          
+          all_poss_cols <- c("RSID", "NS", "NC", "ES", "SE", "LP", "AF", "AC")
+          vr <- vr[, all_poss_cols[all_poss_cols %in% names(mcols(vr))]]
+
           messager("Writing in IEU OpenGWAS VCF format ==> ", save_path)
           VariantAnnotation::writeVcf(
-            obj = VariantAnnotation::asVCF(vr,info='RSID'),
+            obj = VariantAnnotation::asVCF(vr, info = "RSID"),
             ### Must supply filename without compression suffix
             filename = tmp_save_path,
             index = tabix_index
           )
-          
-        }else{
+
+        } else {
           #### Convert to VRanges and save ####
           vr <- to_vranges(sumstats_dt = sumstats_dt)
           messager("Writing in VCF format ==> ", save_path)
@@ -148,16 +148,16 @@ write_sumstats <- function(sumstats_dt,
         }
         #### Compress ####
         ## only compress if this was not already handled by writeVcf(index=T)
-        if(isFALSE(tabix_index)){
-            if(endsWith(save_path,".bgz")){
-                save_path <- Rsamtools::bgzip(tmp_save_path, overwrite=TRUE)
-            } else if(endsWith(save_path,".gz")){
-                save_path <- R.utils::gzip(tmp_save_path, overwrite=TRUE)
+        if (isFALSE(tabix_index)) {
+            if (endsWith(save_path,".bgz")) {
+                save_path <- Rsamtools::bgzip(tmp_save_path, overwrite = TRUE)
+            } else if (endsWith(save_path,".gz")) {
+                save_path <- R.utils::gzip(tmp_save_path, overwrite = TRUE)
             } else {
-                save_path <- tmp_save_path 
+                save_path <- tmp_save_path
             }
         }
-    } else { 
+    } else {
         if (isTRUE(tabix_index)) {
             tmp_save_path <- gsub(".bgz|.gz", "", save_path)
             messager("Writing in tabular format ==>", tmp_save_path)
@@ -169,7 +169,7 @@ write_sumstats <- function(sumstats_dt,
             messager("Writing in tabular format ==>", save_path)
 
         }
-        #### Write to disk #### 
+        #### Write to disk ####
         if (sep == "\t") {
           quotation <- FALSE
           narep <- "NA"
@@ -179,8 +179,8 @@ write_sumstats <- function(sumstats_dt,
         }
 
         data.table::fwrite(
-            x = sumstats_dt, 
-            ### Must be uncompressed so #### 
+            x = sumstats_dt,
+            ### Must be uncompressed so ####
             file = tmp_save_path,
             sep = sep,
             nThread = nThread,
@@ -188,11 +188,12 @@ write_sumstats <- function(sumstats_dt,
             quote = quotation
         )
 
+        if (isTRUE(tabix_index)) {
             save_path <- index_tabular(path = tmp_save_path,
-                                       chrom_col = "CHR", 
-                                       start_col = "BP", 
+                                       chrom_col = "CHR",
+                                       start_col = "BP",
                                        verbose = TRUE)
-        } 
+        }
     }
-    if(isTRUE(return_path)) return(save_path)
+    if (isTRUE(return_path)) return(save_path)
 }

--- a/R/write_sumstats.R
+++ b/R/write_sumstats.R
@@ -158,21 +158,36 @@ write_sumstats <- function(sumstats_dt,
             }
         }
     } else { 
-        messager("Writing in tabular format ==>", save_path)
-        if(isTRUE(tabix_index)){
-            tmp_save_path <- gsub(".bgz|.gz","",save_path)
+        if (isTRUE(tabix_index)) {
+            tmp_save_path <- gsub(".bgz|.gz", "", save_path)
+            messager("Writing in tabular format ==>", tmp_save_path)
+            if (tmp_save_path != save_path) {
+              messager("Writing uncomressed instead of gzipped to enable index")
+            }
         } else {
             tmp_save_path <- save_path
+            messager("Writing in tabular format ==>", save_path)
+
         }
         #### Write to disk #### 
+        if (sep == "\t") {
+          quotation <- FALSE
+          narep <- "NA"
+        } else {
+          quotation <- "auto"
+          narep <- ""
+        }
+
         data.table::fwrite(
             x = sumstats_dt, 
             ### Must be uncompressed so #### 
             file = tmp_save_path,
             sep = sep,
-            nThread = nThread
+            nThread = nThread,
+            na = narep,
+            quote = quotation
         )
-        if(isTRUE(tabix_index)){
+
             save_path <- index_tabular(path = tmp_save_path,
                                        chrom_col = "CHR", 
                                        start_col = "BP", 

--- a/R/write_sumstats.R
+++ b/R/write_sumstats.R
@@ -51,7 +51,7 @@ write_sumstats <- function(sumstats_dt,
         save_path <- check$save_path
     } 
     #### Sort again just to be sure when tabix-indexing ####
-    if(isTRUE(tabix_index) |
+    if (isTRUE(tabix_index) ||
        isTRUE(write_vcf)) {
       sumstats_dt <- sort_coords(sumstats_dt = sumstats_dt)
     }


### PR DESCRIPTION
By default, `data.table::fread()` leaves NAs blank instead of including a literal NA. That's fine for CSVs and if the output is read in by fread, but it breaks other tools for TSVs and is hard to read.

I have updated that and added a message when the table is switched to uncompressed for indexing.

I also replaced a `|` with a `||` for a scalar `OR` in a conditional, and I did some code formatting. If possible, I would love if the literal NA could be integrated. The other stuff is more optional.