### PR TITLE
Allow use of Ensembl chain

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: MungeSumstats
 Type: Package
 Title: Standardise summary statistics from GWAS
-Version: 1.7.1
+Version: 1.7.2
 Authors@R:
     c(person(given = "Alan",
            family = "Murphy",
@@ -52,7 +52,7 @@ Imports:
 biocViews: 
     SNP, WholeGenome, Genetics, ComparativeGenomics, 
     GenomeWideAssociation, GenomicVariation, Preprocessing 
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 Suggests: 

--- a/R/format_sumstats.R
+++ b/R/format_sumstats.R
@@ -45,6 +45,9 @@
 #' @param convert_ref_genome name of the reference genome to convert to
 #' ("GRCh37" or "GRCh38"). This will only occur if the current genome build does
 #' not match. Default is not to convert the genome build (NULL).
+#' @param chain_source name of chain file source to use in liftover, if converting
+#' genome build ("ucsc" or "ensembl"). Note that the UCSC chain files require a
+#' license for commercial use and the UCSC chain is used by default.
 #' @param convert_small_p Binary, should non-negative 
 #' p-values <= 5e-324 be converted to 0?
 #' Small p-values pass the R limit and can cause errors with LDSC/MAGMA and

--- a/R/format_sumstats.R
+++ b/R/format_sumstats.R
@@ -45,9 +45,9 @@
 #' @param convert_ref_genome name of the reference genome to convert to
 #' ("GRCh37" or "GRCh38"). This will only occur if the current genome build does
 #' not match. Default is not to convert the genome build (NULL).
-#' @param chain_source name of chain file source to use in liftover, if converting
+#' @param chain_source source of the chain file to use in liftover, if converting
 #' genome build ("ucsc" or "ensembl"). Note that the UCSC chain files require a
-#' license for commercial use and the UCSC chain is used by default.
+#' license for commercial use, and the UCSC chain is used by default.
 #' @param convert_small_p Binary, should non-negative 
 #' p-values <= 5e-324 be converted to 0?
 #' Small p-values pass the R limit and can cause errors with LDSC/MAGMA and

--- a/R/format_sumstats.R
+++ b/R/format_sumstats.R
@@ -205,6 +205,7 @@
 format_sumstats <- function(path,
                             ref_genome = NULL,
                             convert_ref_genome = NULL,
+                            chain_source = c("ucsc", "ensembl"),
                             convert_small_p = TRUE,
                             convert_large_p = TRUE,
                             convert_neg_p = TRUE,
@@ -259,6 +260,8 @@ format_sumstats <- function(path,
     orig_dims <- NULL
     log_files <- vector(mode = "list")
     t1 <- Sys.time()
+    #### Setup multiple-option args ####
+    chain_source = match.arg(chain_source)
     
     #### Check 1: Ensure save_path is correct.   ####
     check_save_out <- check_save_path(
@@ -936,7 +939,8 @@ format_sumstats <- function(path,
                 sumstats_return$sumstats_dt,
             convert_ref_genome = convert_ref_genome,
             ref_genome = ref_genome,
-            imputation_ind = imputation_ind
+            imputation_ind = imputation_ind,
+            chain_source = chain_source
         )
         #update ref genome of data
         if(!is.null(convert_ref_genome))

--- a/R/get_chain_file.R
+++ b/R/get_chain_file.R
@@ -11,31 +11,40 @@
 #' @importFrom utils download.file
 #' @importFrom R.utils gunzip copyFile
 #' @importFrom rtracklayer import.chain
-get_chain_file <- function(build_conversion = c("hg38ToHg19",
-                                                "hg19ToHg38"), 
+get_chain_file <- function(from = c("hg38", "hg19"),
+                           to = c("hg19", "hg38"),
+                           chain_source = c("ucsc", "ensembl"),
                            save_dir = tempdir(),
                            verbose = TRUE) {
+    #### Match args ####
+    from <- match.arg(from)
+    to <- match.arg(to)
+    chain_source <- match.arg(chain_source)
+    if(from == to){
+        stop("Cannot get a chain file from one reference to the same.")
+    }
+    if(chain_source == "ucsc"){
+        message("Note that you are fetching the UCSC chain file, ",
+        "which requires a licence for commercial use.")
+    }
 
     #### Define paths ####
-    ucsc_ref <- tolower(strsplit(build_conversion, "To")[[1]][1])
-    remote_path <- paste(
-        paste0(
-            "ftp://hgdownload.cse.ucsc.edu/goldenPath/", ucsc_ref,
-            "/liftOver"
-        ),
-        paste0(build_conversion[1], ".over.chain.gz"),
-        sep="/"
+    remote_path = switch(
+        chain_source,
+        "ensembl" = .get_ensembl_chain_remote(from, to),
+        "ucsc" = .get_ucsc_chain_remote(from, to)
     )
     local_path <- file.path(save_dir, basename(remote_path))
     local_path_gunzip <- gsub(".gz", "", local_path)
     ### Download chain file ####
     if(file.exists(local_path_gunzip)){
         if(verbose)
-            messager("Using existing chain file.",v=verbose)
+            messager(sprintf("Using existing chain file from %s.", chain_source),v=verbose)
     }
     else{
+        source_readable = ifelse(chain_source == "ensembl", "Ensembl", "UCSC Genome Browser")
         if(verbose)
-            messager("Downloading chain file from UCSC Genome Browser.",
+            messager(sprintf("Downloading chain file from %s.", source_readable),
                      v=verbose)
         error_dwnld <-
             tryCatch(utils::download.file(remote_path, local_path),
@@ -48,7 +57,7 @@ get_chain_file <- function(build_conversion = c("hg38ToHg19",
                 (grepl("Couldn't connect to server",error_dwnld$message)||
                     grepl("Couldn't resolve host name",error_dwnld$message)))
             ){
-            chain_file <- paste0(build_conversion[1],".over.chain.gz")
+            chain_file <- basename(.get_ucsc_chain_remote(from, to))
             #download.file will create an empty file even if download fails
             if(file.exists(local_path)){
                 rmvd <- file.remove(local_path)
@@ -57,8 +66,8 @@ get_chain_file <- function(build_conversion = c("hg38ToHg19",
                                               package="MungeSumstats"),
                     save_dir)
                 msg <- paste0(
-                    "Download of chain file from UCSC Genome Browser ",
-                    "failed, using package snapshot from 2021-10-07 ",
+                    sprintf("Download of chain file from %s ", source_readable),
+                    "failed, using UCSC package snapshot from 2021-10-07 ",
                     "instead.")
                 message(msg)
             } 
@@ -67,6 +76,38 @@ get_chain_file <- function(build_conversion = c("hg38ToHg19",
         local_path <- R.utils::gunzip(local_path, overwrite=TRUE)
     }
     #### Import ####
+    #ensembl format is slightly different, rtracklayer can't handle the spaces rather than tabs
+    # solution here as per RoelKluin, https://github.com/lawremi/rtracklayer/issues/23
+    if(chain_source == "ensembl"){
+        new_path = gsub(".chain", "_tabs.chain", local_path_gunzip, fixed=TRUE)
+        if(!file.exists(new_path)){
+            system(sprintf(
+                "sed -r 's/^([0-9]+) ([0-9]+) ([0-9]+)$/\\1\\t\\2\\t\\3/' %s > %s",
+                local_path_gunzip, new_path)
+            )
+        }
+        local_path_gunzip = new_path
+    }
     chain <- rtracklayer::import.chain(local_path_gunzip)
     return(chain)
+}
+
+.get_ensembl_chain_remote <- function(from = c("hg38", "hg19"),
+                                      to = c("hg19", "hg38")) {
+    base <- "ftp://ftp.ensembl.org/pub/assembly_mapping/homo_sapiens/"
+    ens_convert <- c("hg38" = "GRCh38", "hg19" = "GRCh37")
+    ens_from <- ens_convert[from]
+    ens_to <- ens_convert[to]
+    return(
+        paste0(base, ens_from, "_to_", ens_to, ".chain.gz")
+    )
+}
+
+.get_ucsc_chain_remote <- function(from = c("hg38", "hg19"),
+                                      to = c("hg19", "hg38")) {
+    base <- "ftp://hgdownload.cse.ucsc.edu/goldenPath/"
+    to_caps <- paste0(toupper(substr(to, 1, 1)),substr(to, 2, nchar(to)))
+    return(
+        paste0(base, from, "/liftOver/", from, "To", to_caps, ".over.chain.gz")
+    )
 }

--- a/R/get_chain_file.R
+++ b/R/get_chain_file.R
@@ -2,8 +2,11 @@
 #'
 #' @source \href{https://hgdownload.cse.ucsc.edu/goldenpath/hg19/liftOver/}{
 #' UCSC chain files}
-#' @param build_conversion converting from what build to what? hg38ToHg19 or
-#' hg19ToHg38 
+#' @source \href{https://ftp.ensembl.org/pub/assembly_mapping/homo_sapiens/}{
+#' Ensembl chain files}
+#' @param from genome build converted from ("hg38", "hg19")
+#' @param to genome build converted to ("hg19", "hg38")
+#' @param chain_source chain file source used ("ucsc" as default, or "ensembl")
 #' @param save_dir where is the chain file saved? Default is a temp directory
 #' @param verbose extra messages printed? Default is TRUE
 #' @return loaded chain file for liftover
@@ -76,8 +79,9 @@ get_chain_file <- function(from = c("hg38", "hg19"),
         local_path <- R.utils::gunzip(local_path, overwrite=TRUE)
     }
     #### Import ####
-    #ensembl format is slightly different, rtracklayer can't handle the spaces rather than tabs
-    # solution here as per RoelKluin, https://github.com/lawremi/rtracklayer/issues/23
+    # Ensembl format is slightly different to UCSC, rtracklayer can't handle 
+    # the spaces rather than tabs. Solution here as per RoelKluin
+    # https://github.com/lawremi/rtracklayer/issues/23
     if(chain_source == "ensembl"){
         new_path = gsub(".chain", "_tabs.chain", local_path_gunzip, fixed=TRUE)
         if(!file.exists(new_path)){

--- a/R/liftover.R
+++ b/R/liftover.R
@@ -5,9 +5,12 @@
 #' @source \href{https://doi.org/doi:10.18129/B9.bioc.liftOver}{liftOver}
 #' @source \href{https://hgdownload.cse.ucsc.edu/goldenpath/hg19/liftOver/}{
 #' UCSC chain files}
+#' @source \href{https://ftp.ensembl.org/pub/assembly_mapping/homo_sapiens/}{
+#' Ensembl chain files}
 #'
 #' @param sumstats_dt data table obj of the summary statistics
 #'  file for the GWAS.
+#' @param chain_source chain file source used ("ucsc" as default, or "ensembl")
 #' @param chrom_col Name of the chromosome column in 
 #' \code{sumstats_dt} (e.g. "CHR").
 #' @param start_col Name of the starting genomic position
@@ -85,7 +88,8 @@ liftover <- function(sumstats_dt,
           #### Check that liftover is available ####
           ## If one or more builds are NULL, this won't be evaluated bc
           ## the builds will be inferred instead.
-          if(any(!c(query_ucsc, target_ucsc) %in% c("hg38", "hg19")) || query_ucsc == target_ucsc) {
+          if(any(!c(query_ucsc, target_ucsc) %in% c("hg38", "hg19")) ||
+                 query_ucsc == target_ucsc) {
               stop("Can only perform liftover between hg19 <---> hg38")
           } 
           #### Convert to GRanges #### 

--- a/R/liftover.R
+++ b/R/liftover.R
@@ -39,7 +39,8 @@
 #'                              convert_ref_genome="hg38")
 liftover <- function(sumstats_dt, 
                      convert_ref_genome, 
-                     ref_genome, 
+                     ref_genome,
+                     chain_source = c("ucsc", "ensembl"),
                      imputation_ind = TRUE,
                      chrom_col = "CHR",
                      start_col = "BP",
@@ -49,7 +50,7 @@ liftover <- function(sumstats_dt,
                      verbose = TRUE) {
     
     IMPUTATION_gen_build <- width <- strand <- end <- seqnames <- NULL;
-    
+    chain_source <- match.arg(chain_source)
     #Only continue with checks if user specifies a genome to convert to
     if (!is.null(convert_ref_genome)){
       #### Map genome build synonyms ####
@@ -84,11 +85,7 @@ liftover <- function(sumstats_dt,
           #### Check that liftover is available ####
           ## If one or more builds are NULL, this won't be evaluated bc
           ## the builds will be inferred instead.
-          if(query_ucsc=="hg38" && target_ucsc=="hg19") {
-              build_conversion <- "hg38ToHg19"
-          } else if (query_ucsc=="hg19" && target_ucsc=="hg38"){
-              build_conversion <- "hg19ToHg38"
-          } else {
+          if(any(!c(query_ucsc, target_ucsc) %in% c("hg38", "hg19")) || query_ucsc == target_ucsc) {
               stop("Can only perform liftover between hg19 <---> hg38")
           } 
           #### Convert to GRanges #### 
@@ -101,7 +98,9 @@ liftover <- function(sumstats_dt,
           )
           #### Specify chain file ####
           chain <- get_chain_file(
-              build_conversion = build_conversion,
+              from = query_ucsc,
+              to = target_ucsc,
+              chain_source = chain_source,
               verbose = verbose
           )
           #### Liftover ####

--- a/man/format_sumstats.Rd
+++ b/man/format_sumstats.Rd
@@ -71,9 +71,9 @@ reference genome from the data.}
 ("GRCh37" or "GRCh38"). This will only occur if the current genome build does
 not match. Default is not to convert the genome build (NULL).}
 
-\item{chain_source}{name of chain file source to use in liftover, if converting
+\item{chain_source}{source of the chain file to use in liftover, if converting
 genome build ("ucsc" or "ensembl"). Note that the UCSC chain files require a
-license for commercial use and the UCSC chain is used by default.}
+license for commercial use, and the UCSC chain is used by default.}
 
 \item{convert_small_p}{Binary, should non-negative
 p-values <= 5e-324 be converted to 0?

--- a/man/format_sumstats.Rd
+++ b/man/format_sumstats.Rd
@@ -8,6 +8,7 @@ format_sumstats(
   path,
   ref_genome = NULL,
   convert_ref_genome = NULL,
+  chain_source = c("ucsc", "ensembl"),
   convert_small_p = TRUE,
   convert_large_p = TRUE,
   convert_neg_p = TRUE,
@@ -69,6 +70,10 @@ reference genome from the data.}
 \item{convert_ref_genome}{name of the reference genome to convert to
 ("GRCh37" or "GRCh38"). This will only occur if the current genome build does
 not match. Default is not to convert the genome build (NULL).}
+
+\item{chain_source}{name of chain file source to use in liftover, if converting
+genome build ("ucsc" or "ensembl"). Note that the UCSC chain files require a
+license for commercial use and the UCSC chain is used by default.}
 
 \item{convert_small_p}{Binary, should non-negative
 p-values <= 5e-324 be converted to 0?

--- a/man/get_chain_file.Rd
+++ b/man/get_chain_file.Rd
@@ -6,17 +6,25 @@
 \source{
 \href{https://hgdownload.cse.ucsc.edu/goldenpath/hg19/liftOver/}{
 UCSC chain files}
+
+\href{https://ftp.ensembl.org/pub/assembly_mapping/homo_sapiens/}{
+Ensembl chain files}
 }
 \usage{
 get_chain_file(
-  build_conversion = c("hg38ToHg19", "hg19ToHg38"),
+  from = c("hg38", "hg19"),
+  to = c("hg19", "hg38"),
+  chain_source = c("ucsc", "ensembl"),
   save_dir = tempdir(),
   verbose = TRUE
 )
 }
 \arguments{
-\item{build_conversion}{converting from what build to what? hg38ToHg19 or
-hg19ToHg38}
+\item{from}{genome build converted from ("hg38", "hg19")}
+
+\item{to}{genome build converted to ("hg19", "hg38")}
+
+\item{chain_source}{chain file source used ("ucsc" as default, or "ensembl")}
 
 \item{save_dir}{where is the chain file saved? Default is a temp directory}
 

--- a/man/import_sumstats.Rd
+++ b/man/import_sumstats.Rd
@@ -65,6 +65,9 @@ reference genome from the data.}
     \item{\code{convert_ref_genome}}{name of the reference genome to convert to
 ("GRCh37" or "GRCh38"). This will only occur if the current genome build does
 not match. Default is not to convert the genome build (NULL).}
+    \item{\code{chain_source}}{name of chain file source to use in liftover, if converting
+genome build ("ucsc" or "ensembl"). Note that the UCSC chain files require a
+license for commercial use and the UCSC chain is used by default.}
     \item{\code{convert_small_p}}{Binary, should non-negative
 p-values <= 5e-324 be converted to 0?
 Small p-values pass the R limit and can cause errors with LDSC/MAGMA and

--- a/man/import_sumstats.Rd
+++ b/man/import_sumstats.Rd
@@ -65,9 +65,9 @@ reference genome from the data.}
     \item{\code{convert_ref_genome}}{name of the reference genome to convert to
 ("GRCh37" or "GRCh38"). This will only occur if the current genome build does
 not match. Default is not to convert the genome build (NULL).}
-    \item{\code{chain_source}}{name of chain file source to use in liftover, if converting
+    \item{\code{chain_source}}{source of the chain file to use in liftover, if converting
 genome build ("ucsc" or "ensembl"). Note that the UCSC chain files require a
-license for commercial use and the UCSC chain is used by default.}
+license for commercial use, and the UCSC chain is used by default.}
     \item{\code{convert_small_p}}{Binary, should non-negative
 p-values <= 5e-324 be converted to 0?
 Small p-values pass the R limit and can cause errors with LDSC/MAGMA and

--- a/man/liftover.Rd
+++ b/man/liftover.Rd
@@ -8,12 +8,16 @@
 
 \href{https://hgdownload.cse.ucsc.edu/goldenpath/hg19/liftOver/}{
 UCSC chain files}
+
+\href{https://ftp.ensembl.org/pub/assembly_mapping/homo_sapiens/}{
+Ensembl chain files}
 }
 \usage{
 liftover(
   sumstats_dt,
   convert_ref_genome,
   ref_genome,
+  chain_source = c("ucsc", "ensembl"),
   imputation_ind = TRUE,
   chrom_col = "CHR",
   start_col = "BP",
@@ -34,6 +38,8 @@ not match. Default is not to convert the genome build (NULL).}
 \item{ref_genome}{name of the reference genome used for the GWAS ("GRCh37" or
 "GRCh38"). Argument is case-insensitive. Default is NULL which infers the
 reference genome from the data.}
+
+\item{chain_source}{chain file source used ("ucsc" as default, or "ensembl")}
 
 \item{imputation_ind}{Binary Should a column be added for each imputation
 step to show what SNPs have imputed values for differing fields. This


### PR DESCRIPTION
Nice work with this package - it is extremely useful.

As you've noted, the UCSC chain files require a licence for commercial use. Fortunately, Ensembl also provide chain files. The changes I have made allow use of the Ensembl chain files for liftOver.

I haven't done two things:
1. Remove the UCSC chain files included in the package
2. Add tests for UCSC/Ensembl result equality. I'm not sure if the chain files are meant to give exactly the same results, so a mismatching mapping might not be incorrect. Though I did compare the results for the two chains for a single GWAS I downloaded, and the results were identical.

Let me know what you think!

Jonny.