### PR TITLE
Fix bug in standardise_sumstats_column_headers_crossplatform

### DIFF
--- a/R/standardise_sumstats_column_headers_crossplatform.R
+++ b/R/standardise_sumstats_column_headers_crossplatform.R
@@ -48,7 +48,7 @@ standardise_header <- standardise_sumstats_column_headers_crossplatform <-
         for (headerI in seq_len(nrow(mapping_file))) {
             un <- mapping_file[headerI, "UNCORRECTED"]
             cr <- mapping_file[headerI, "CORRECTED"]
-            if (un %in% column_headers & (!cr %in% column_headers)) {
+            if (un %in% column_headers & !(cr %in% column_headers)) {
                 data.table::setnames(sumstats_dt, un, cr)
             }
         }


### PR DESCRIPTION
Hi!
Thanks for all the great work on the package! It's mind-boggling how messy working with GWAS sumstats is and your package is an enormous help. I've found a few things that could be improved in the function [standardise_sumstats_column_headers_crossplatform.R](https://github.com/neurogenomics/MungeSumstats/compare/master...cfbeuchel:MungeSumstats:column_header_patch?expand=1#diff-04bf6e661de3acedc281cbbd6d6ff873d714d22a4c3d274dabbe6ff3ad2749b1), but this is, at least I think, simply a small bug that could be fixed. I'm sorry if it's wrong, but I am pretty sure `(!cr %in% column_headers)` makes no sense (`cr` is a column name) and the correct part of this `if`-statement should be `!(cr %in% column_headers)`. 

Commit message:

Fix a wrongly placed `!` that should make sure a `Corrected` column name is not in the table. Was simply inside instead of outside of the brackets.