### PR TITLE
Patch standardise sumstats column headers crossplatform (+QOL improvements)

### DIFF
--- a/R/standardise_sumstats_column_headers_crossplatform.R
+++ b/R/standardise_sumstats_column_headers_crossplatform.R
@@ -29,6 +29,12 @@ standardise_header <- standardise_sumstats_column_headers_crossplatform <-
             "Mapping file must be a data.frame!" =
             !data.table::is.data.table(mapping_file)
         )
+          if(nrow(mapping_file) != nrow(sumstatsColHeaders)) {
+        message(
+            "Non-standard mapping file detected.",
+            "Making sure all entries in `Uncorrected` are in upper case.")
+        mapping_file$Uncorrected <- toupper(mapping_file$Uncorrected)
+        }
         message("Standardising column headers.")
         message("First line of summary statistics file: ")
         msg <- paste0(names(sumstats_dt), split = "\t")

--- a/R/standardise_sumstats_column_headers_crossplatform.R
+++ b/R/standardise_sumstats_column_headers_crossplatform.R
@@ -27,7 +27,7 @@ standardise_header <- standardise_sumstats_column_headers_crossplatform <-
           
         stopifnot(
             "Mapping file must be a data.frame!" =
-            !is.data.table(mapping_file)
+            !data.table::is.data.table(mapping_file)
         )
         message("Standardising column headers.")
         message("First line of summary statistics file: ")

--- a/R/standardise_sumstats_column_headers_crossplatform.R
+++ b/R/standardise_sumstats_column_headers_crossplatform.R
@@ -27,7 +27,7 @@ standardise_header <- standardise_sumstats_column_headers_crossplatform <-
           
         stopifnot(
             "Mapping file must be a data.frame!" =
-            !is.data.table(sumstatsColHeaders)
+            !is.data.table(mapping_file)
         )
         message("Standardising column headers.")
         message("First line of summary statistics file: ")
@@ -36,7 +36,7 @@ standardise_header <- standardise_sumstats_column_headers_crossplatform <-
         #### Store original colnames #####
         ## In case we want to use the original casing 
         ## IMPORTANT! Must use copy() function or else this vector will get 
-        ## changed when the data.table it comes from gets changed.
+        ## changed when the data.table it comes from gets cmy_sumstatsColHeadershanged.
         names_og <- data.table::copy(names(sumstats_dt))
         #### first make all column headers upper case ####
         data.table::setnames(sumstats_dt, toupper(names(sumstats_dt))) 

--- a/R/standardise_sumstats_column_headers_crossplatform.R
+++ b/R/standardise_sumstats_column_headers_crossplatform.R
@@ -36,7 +36,7 @@ standardise_header <- standardise_sumstats_column_headers_crossplatform <-
         #### Store original colnames #####
         ## In case we want to use the original casing 
         ## IMPORTANT! Must use copy() function or else this vector will get 
-        ## changed when the data.table it comes from gets cmy_sumstatsColHeadershanged.
+        ## changed when the data.table it comes from gets changed.
         names_og <- data.table::copy(names(sumstats_dt))
         #### first make all column headers upper case ####
         data.table::setnames(sumstats_dt, toupper(names(sumstats_dt))) 

--- a/R/standardise_sumstats_column_headers_crossplatform.R
+++ b/R/standardise_sumstats_column_headers_crossplatform.R
@@ -52,7 +52,7 @@ standardise_header <- standardise_sumstats_column_headers_crossplatform <-
         for (headerI in seq_len(nrow(mapping_file))) {
             un <- mapping_file[headerI, "UNCORRECTED"]
             cr <- mapping_file[headerI, "CORRECTED"]
-            if (un %in% column_headers & (!cr %in% column_headers)) {
+            if (un %in% column_headers & !(cr %in% column_headers)) {
                 data.table::setnames(sumstats_dt, un, cr)
             }
         }

--- a/R/standardise_sumstats_column_headers_crossplatform.R
+++ b/R/standardise_sumstats_column_headers_crossplatform.R
@@ -14,7 +14,7 @@
 #' @return list containing sumstats_dt, the modified summary statistics data
 #' table object
 #' @export
-#' @importFrom data.table setnames rbindlist
+#' @importFrom data.table setnames rbindlist is.data.table
 #' @examples
 #' sumstats_dt <- data.table::fread(system.file("extdata", "eduAttainOkbay.txt",
 #'                                              package = "MungeSumstats"))
@@ -25,6 +25,10 @@ standardise_header <- standardise_sumstats_column_headers_crossplatform <-
              uppercase_unmapped=TRUE,
              return_list=TRUE) {
           
+        stopifnot(
+            "Mapping file must be a data.frame!" =
+            !is.data.table(sumstatsColHeaders)
+        )
         message("Standardising column headers.")
         message("First line of summary statistics file: ")
         msg <- paste0(names(sumstats_dt), split = "\t")


### PR DESCRIPTION
Hi!
This is my second PR for the function `standardise_sumstats_column_headers_crossplatform()`. This PR includes the bugfix from the other PR plus some QOL improvements, at least for me. Feel free to merge either one (or none of course), whatever you think best.

Just to explain: I am using a custom mapping file for `format_sumstats()` and ran into continuous errors due to being a scatterbrain and maybe some ambiguities in the code that could be avoided. These are:

1. The mapping table must be a data.frame
2. The entries in `mapping_file$Uncorrected` must be in upper case

Point 1 is simply a problem when you, as I do, prefer to work in `data.table`, but a function explicitly requires a data.frame. Passing a data.table to the function will cause it to fail weirdly downstream, so I thought it useful to introduce a check. Something else might also work (maybe `all(class(mapping_file) == "data.frame")`), but at least this way, *my* common error of submitting a DT is caught early.

Point 2 is I think a more generally useful check because it is not mentioned anywhere explicitly. This is that the formatting check turns all column names to UPPERCASE. Therefore, entering the original column names (`myBadCol` or whatever) will not be corrected, because the function will only check for `MYBADCOL` in mapping_file$Uncorrected. Therefore, I thought it useful to turn everything in `mapping_file` to upper case when a custom table is supplied.

Let me know what you think!

Again, thanks for the work on the package, you've saved me a lot of time and headache.

Cheers,
Carl