### PR TITLE
Add checks to standardise_sumstats_column_headers_crossplatform()

### DIFF
--- a/R/standardise_sumstats_column_headers_crossplatform.R
+++ b/R/standardise_sumstats_column_headers_crossplatform.R
@@ -14,7 +14,7 @@
 #' @return list containing sumstats_dt, the modified summary statistics data
 #' table object
 #' @export
-#' @importFrom data.table setnames rbindlist
+#' @importFrom data.table setnames rbindlist setDF
 #' @examples
 #' sumstats_dt <- data.table::fread(system.file("extdata", "eduAttainOkbay.txt",
 #'                                              package = "MungeSumstats"))
@@ -24,7 +24,17 @@ standardise_header <- standardise_sumstats_column_headers_crossplatform <-
              mapping_file = sumstatsColHeaders,
              uppercase_unmapped=TRUE,
              return_list=TRUE) {
-          
+        
+        data.table::setDF(mapping_file)
+        if(!all.equal(
+            mapping_file, 
+            sumstatsColHeaders
+        )) {
+            message(
+                "Non-standard mapping file detected.",
+                "Making sure all entries in `Uncorrected` are in upper case.")
+            mapping_file$Uncorrected <- toupper(mapping_file$Uncorrected)
+        }
         message("Standardising column headers.")
         message("First line of summary statistics file: ")
         msg <- paste0(names(sumstats_dt), split = "\t")


### PR DESCRIPTION
As discussed in #174, I've implemented your suggestions. I prefer `setDF` to `as.data.frame` as it changes by reference only. It might also be useful to put the conversion in the conditional statement, but I don't think it hurts, since in case someone supplies the identical mapping file for whatever reason, the conversion might avoid errors.